### PR TITLE
Add Flask web UI with Ingress support

### DIFF
--- a/minecraftserver/Dockerfile
+++ b/minecraftserver/Dockerfile
@@ -24,9 +24,11 @@ ARG MC_MONITOR_VERSION
 # Tools installeren en up to date maken
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl unzip jq
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip
 RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*
 
+RUN pip3 install --no-cache-dir flask
 
 # Instal box64 on arm
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
@@ -45,11 +47,14 @@ RUN echo "🧱 Bedrock Server version: ${BDS_VERSION}"
 RUN echo "🌐 Bedrock Server URL: ${BDS_URL}"
 
 # Default bedrock poort openen.
-EXPOSE 19132/udp
+EXPOSE 19132/udp 8789/tcp
+
 VOLUME ["/data"]
 WORKDIR /data
 
-ENTRYPOINT ["/usr/local/bin/entrypoint-demoter", "--match", "/data", "--debug", "--stdin-on-term", "stop", "/opt/bedrock-entry.sh"]
+#ENTRYPOINT ["/usr/local/bin/entrypoint-demoter", "--match", "/data", "--debug", "--stdin-on-term", "stop", "/opt/bedrock-entry.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint-demoter", "--match", "/data", "--debug", "--stdin-on-term", "stop", "/opt/start.sh"]
+
 
 ARG EASY_ADD_VERSION
 
@@ -61,12 +66,17 @@ RUN easy-add --var version=${SET_PROPERTY_VERSION} --var app=set-property --file
 RUN easy-add --var version=${RESTIFY_VERSION} --var app=restify --file {{.app}} --from https://github.com/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_linux_${TARGETARCH}.tar.gz
 RUN easy-add --var version=${MC_MONITOR_VERSION} --var app=mc-monitor --file {{.app}} --from https://github.com/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_linux_${TARGETARCH}.tar.gz
 
-# Bestanden add-on toevoegen.
+# Bestanden naar container kopiëren
 COPY bedrock-entry.sh /opt/bedrock-entry.sh
 COPY *.mcpack /opt/addons/
 COPY property-definitions.json /etc/bds-property-definitions.json
+COPY web/app.py /opt/flask/app.py
 COPY bin/* /usr/local/bin/
+
+# Maak scripts uitvoerbaar
 RUN chmod +x /opt/bedrock-entry.sh
+RUN chmod +x /opt/start.sh
+
 
 # ===== Download & uitpakken tijdens build =====
 # (1) Downloaden

--- a/minecraftserver/config.yaml
+++ b/minecraftserver/config.yaml
@@ -5,6 +5,12 @@ slug: "minecraft_server_for_ha"
 url: https://github.com/KevinHekert/HomeAssistantAddOns/blob/main/minecraftserver/README.md
 init: false
 startup: application
+
+ingress: true
+ingress_port: 8789         # moet overeenkomen met Flask-poort
+panel_icon: mdi:minecraft  # optioneel, leuk voor in de sidebar
+panel_title: "Minecraft Server"
+
 host_network: true
 arch:
   - amd64

--- a/minecraftserver/run.sh
+++ b/minecraftserver/run.sh
@@ -1,1 +1,0 @@
-#!/usr/bin/with-contenv bashio

--- a/minecraftserver/start.sh
+++ b/minecraftserver/start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+FLASK_PORT="${FLASK_PORT:-8080}"
+
+echo "🚀 Starting Flask webserver on port ${FLASK_PORT}..."
+python3 /opt/flask/app.py &
+
+echo "🎮 Starting Bedrock server..."
+exec /opt/bedrock-entry.sh "$@"

--- a/minecraftserver/web/app.py
+++ b/minecraftserver/web/app.py
@@ -1,0 +1,24 @@
+from flask import Flask, render_template_string
+
+app = Flask(__name__)
+
+HTML = """
+<!doctype html>
+<html>
+  <head>
+    <title>Minecraft Bedrock UI</title>
+  </head>
+  <body>
+    <h1>Minecraft Bedrock Server</h1>
+    <p>Hier komt je status/config UI etc.</p>
+  </body>
+</html>
+"""
+
+@app.route("/")
+def index():
+    return HTML
+
+if __name__ == "__main__":
+    # Belangrijk voor Ingress: 0.0.0.0 en vaste poort
+    app.run(host="0.0.0.0", port=8789)


### PR DESCRIPTION
- Added Flask application files for the new web UI
- Updated Dockerfile to install Python/Flask and expose the Flask port
- Added unified start script to launch both Flask and Bedrock server
- Updated add-on config.yaml to enable Ingress and point to Flask port
- Adjusted ENTRYPOINT to route through the new Flask-capable startup script