### PR TITLE
Changed way to install flask, using apt-get instead of pip

### DIFF
--- a/minecraftserver/Dockerfile
+++ b/minecraftserver/Dockerfile
@@ -24,11 +24,9 @@ ARG MC_MONITOR_VERSION
 # Tools installeren en up to date maken
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl unzip jq
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip python3-flask
 RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*
-
-RUN pip3 install --no-cache-dir flask
 
 # Instal box64 on arm
 RUN if [ "$TARGETARCH" = "arm64" ]; then \


### PR DESCRIPTION
Changed way to install flask, using apt-get instead of pip